### PR TITLE
Added RewriteRule for /wp-json API route

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,6 +5,7 @@ RewriteBase /
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule . - [L]
+RewriteRule ^wp-json/(.*)$ index.php?json=$1&%{QUERY_STRING} [L]
 RewriteRule  ^([_0-9a-zA-Z-]+/)?(wp-.*) /wp/$2 [L]
 RewriteRule  ^([_0-9a-zA-Z-]+/)?(.*\.php)$ /wp/$2 [L]
 RewriteRule . index.php [L]


### PR DESCRIPTION
Hey there. Thanks for sharing your WordPress skeleton. I've employed it with great success. All was working fine until I installed the [Contact Form 7](https://wordpress.org/plugins/contact-form-7/) plugin, which didn't seem to function when Send was clicked on the form. I traced this down in the apache log to a redirect loop against the path `/wp-json/contact-form-7/v1/contact-forms/108/feedback`.

I'm not sure if the plugin isn't generic enough in its handling of the API, if something is off against my setup, or if WordPress has changed since your last commit, but I would assume this would occur for any attempts to utilize the WordPress API in this manner? This rewrite rule fixed the issue for me.

Sample from apache error.log:

    [Sun Aug 06 11:13:27.282100 2017] [core:error] [pid 22659] [client xx.xx.xxx.xx:xxxx] AH00124: Request 
    exceeded the limit of 10 internal redirects due to probable configuration error. Use 
    'LimitInternalRecursion' to increase the limit if necessary. Use 'LogLevel debug' to get a backtrace.
